### PR TITLE
assert config is valid

### DIFF
--- a/src/subcommands/run.rs
+++ b/src/subcommands/run.rs
@@ -23,6 +23,8 @@ impl RunSubcommand {
     pub async fn execute(self) {
         let config = Config::from_toml(self.config_file_path).expect("Failed to load config");
 
+        config.ensure_valid_configuration();
+
         let services_init_ret = Self::init_services(config).await;
 
         if services_init_ret.is_err() {

--- a/src/types/config_types.rs
+++ b/src/types/config_types.rs
@@ -19,6 +19,37 @@ impl Config {
         std::fs::write(config_file_path, content)?;
         Ok(())
     }
+
+    pub fn ensure_valid_configuration(&self) {
+        assert_ne!(
+            self.haiku.db_config.vector_size, "0",
+            "Vector size cannot be zero."
+        );
+
+        assert_ne!(
+            self.haiku.llm.chat_completion_provider, "",
+            "Chat completion provider cannot be empty."
+        );
+
+        assert_ne!(self.haiku.llm.ai_model, "", "AI model cannot be empty.");
+
+        assert_ne!(self.haiku.llm.ai_url, "", "AI URL cannot be empty.");
+
+        assert_ne!(
+            self.haiku.llm.embedding_provider, "",
+            "Embedding provider cannot be empty."
+        );
+
+        assert_ne!(
+            self.haiku.llm.embedding_model, "",
+            "Embedding model cannot be empty."
+        );
+
+        assert_ne!(
+            self.haiku.llm.embedding_url, "",
+            "Embedding URL cannot be empty."
+        );
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]

--- a/src/types/config_types.rs
+++ b/src/types/config_types.rs
@@ -49,6 +49,20 @@ impl Config {
             self.haiku.llm.embedding_url, "",
             "Embedding URL cannot be empty."
         );
+
+        if self.haiku.llm.embedding_provider == "openai" {
+            assert_ne!(
+                self.haiku.llm.embedding_token, "",
+                "Missing API key for OpenAI embedding"
+            );
+        }
+
+        if self.haiku.llm.chat_completion_provider == "openai" {
+            assert_ne!(
+                self.haiku.llm.ai_token, "",
+                "Missing API key for OpenAI chat completion"
+            );
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #49

We don't set the vector size dynamically. Instead, we use asserts to ensure the config is valid at runtime